### PR TITLE
fix(config): load file with native pathToFileURL()

### DIFF
--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -5,6 +5,7 @@ import { confirm, outro, text } from "@clack/prompts";
 import chalk from "chalk";
 import dedent from "dedent";
 import type { Config } from "./types.js";
+import { pathToFileURL } from 'url';
 
 export async function getApiKey(name: string, key: string) {
   if (key in process.env) {
@@ -64,7 +65,7 @@ export const configPath = path.join(process.cwd(), "languine.config.mjs");
 export async function getConfig() {
   let config: Config;
   try {
-    const configModule = await import(configPath);
+    const configModule = await import(pathToFileURL(configPath).href);
     config = configModule.default;
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
`getConfig()` was failing to load `languine.config.mjs`:

```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: 
file, data, and node are supported by the default ESM loader. 
On Windows, absolute paths must be valid file:// URLs. Received protocol 'e:'
```

Changed the `import()` to use the native `pathToFileURL()` before loading the file to prevent the error. It's cross-platform and also normalizes Windows drive letters/relative paths.

Tests:
- ✅ Windows from drive-based path (`E:\`)
- ✅ Linux
- ✅ MacOS