### PR TITLE
Remove dot in front of "po"

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -41,7 +41,7 @@ function getDefaultPattern(format: string) {
       return "locales/[locale].json";
     case "md":
       return "docs/[locale]/*.md";
-    case ".po":
+    case "po":
       return "locales/[locale].po";
     case "xml":
       return "locales/[locale].xml";


### PR DESCRIPTION
I wanted to try Languine with po files and noticed an error:

```
npx languine@latest                       20s

    ██╗      █████╗ ███╗   ██╗ ██████╗ ██╗   ██╗██╗███╗   ██╗███████╗
    ██║     ██╔══██╗████╗  ██║██╔════╝ ██║   ██║██║████╗  ██║██╔════╝
    ██║     ███████║██╔██╗ ██║██║  ███╗██║   ██║██║██║██╗ ██║█████╗
    ██║     ██╔══██║██║╚██╗██║██║   ██║██║   ██║██║██║╚██╗██║██╔══╝
    ███████╗██║  ██║██║ ╚████║╚██████╔╝╚██████╔╝██║██║ ╚████║███████╗
    ╚══════╝╚═╝  ╚═╝╚═╝  ╚═══╝ ╚═════╝  ╚═════╝ ╚═╝╚═╝  ╚═══╝╚══════╝

Translate your application with Languine CLI powered by AI.
Website: https://languine.ai

│
◇  What would you like to do?
│  Initialize a new Languine configuration
┌  Let's set up your i18n configuration
│
◇  What is your source language?
│  English
│
◇  What languages do you want to translate to?
│  no
│
◇  What format should language files use?
│  Gettext (.po)
file:///Users/andreas/.npm/_npx/8e2b6b35c5047a76/node_modules/languine/dist/index.js:356
      throw new Error(`Unsupported format: ${format}`);
            ^

Error: Unsupported format: po
    at getDefaultPattern (file:///Users/andreas/.npm/_npx/8e2b6b35c5047a76/node_modules/languine/dist/index.js:356:13)
    at init (file:///Users/andreas/.npm/_npx/8e2b6b35c5047a76/node_modules/languine/dist/index.js:400:26)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    
```
    
Looks like the issue was that a dot was prefixing `po` in switch that checked for valid file extensions in `getDefaultPattern`. 
   
After removing it, I was able to create a config file:
   
   
```
   ◇  What format should language files use?
│  Gettext (.po)
│
◇  Where should language files be stored?
│  locales/[locale].po
│
◇  Which provider would you like to use?
│  OpenAI
│
◇  Which model should be used for translations?
│  GPT-4 Turbo (Default)
│
└  Configuration file and language files/directories created successfully!
```