### PR TITLE
Fix missing "ts" case in getDefaultPattern

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -29,6 +29,8 @@ async function createDirectoryOrFile(filePath: string, isDirectory = false) {
 
 function getDefaultPattern(format: string) {
   switch (format) {
+    case "ts":
+      return "locales/[locale].ts";
     case "xcode-strings":
       return "Example/[locale].lproj/Localizable.strings";
     case "xcode-stringsdict":


### PR DESCRIPTION
When running the translate command and selecting "TypeScript (.ts)" for "What format should language files use?", a runtime error occurs.