### PR TITLE
Handle empty models list for Ollama

### DIFF
--- a/packages/cli/src/providers.ts
+++ b/packages/cli/src/providers.ts
@@ -38,6 +38,15 @@ export const providers: Record<Provider, ProviderConfig> = {
       try {
         const { models } = await ollama.list();
 
+        if (models.length === 0) {
+          outro(
+            chalk.red(
+              "No Ollama models found. Please install at least one model."
+            ),
+          );
+          process.exit(1);
+        }
+
         return models.map((model) => ({
           value: model.name,
           label: model.name,


### PR DESCRIPTION
## Description

When no Ollama models are installed, the CLI throws a TypeError when trying to select a model. This PR adds a proper error message for users.

Error: `TypeError: Cannot read properties of undefined (reading 'value')`

## Changes

```typescript
if (models.length === 0) {
  outro(
    chalk.red(
      "No Ollama models found. Please install at least one model."
    ),
  );
  process.exit(1);
}
```

## Tested steps

1. Remove all Ollama models
2. Run languine init
3. Select Ollama provider
4. Verify the error message appears